### PR TITLE
Allow disabling adding access policy (and remove unused var)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ No requirements.
 | ssl\_mode | Certificate source to encrypt HTTPS traffic with. eg. AzureKeyVault, FrontDoor | `string` | n/a | yes |
 | subscription | Name of the subscription to deploy frontdoor, e.g. stg | `string` | n/a | yes |
 | subscription\_id | Enter Subscription ID | `string` | n/a | yes |
+| add\_access\_policy | Whether to add an access policy for frontdoor to the subscription key vault, disable if there's multiple front doors in one subscription | `bool` | true | no |
 
 ## Outputs
 

--- a/frontdoor_kv_access.tf
+++ b/frontdoor_kv_access.tf
@@ -1,5 +1,5 @@
 resource "azurerm_key_vault_access_policy" "frontdoor_kv_access" {
-  count = var.add_access_policy == true ? 1 : 0
+  count        = var.add_access_policy == true ? 1 : 0
   key_vault_id = data.azurerm_key_vault.certificate_vault.id
 
   object_id = "0a7e9367-4349-4b24-974a-bfa7b23a38fc"

--- a/frontdoor_kv_access.tf
+++ b/frontdoor_kv_access.tf
@@ -1,4 +1,5 @@
 resource "azurerm_key_vault_access_policy" "frontdoor_kv_access" {
+  count = var.add_access_policy == true ? 1 : 0
   key_vault_id = data.azurerm_key_vault.certificate_vault.id
 
   object_id = "0a7e9367-4349-4b24-974a-bfa7b23a38fc"

--- a/providers.tf
+++ b/providers.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 2.41.0"
+      configuration_aliases = [ azurerm.data ]
+    }
+  }
+}

--- a/providers.tf
+++ b/providers.tf
@@ -1,9 +1,9 @@
 terraform {
   required_providers {
     azurerm = {
-      source  = "hashicorp/azurerm"
-      version = ">= 2.41.0"
-      configuration_aliases = [ azurerm.data ]
+      source                = "hashicorp/azurerm"
+      version               = ">= 2.41.0"
+      configuration_aliases = [azurerm.data]
     }
   }
 }

--- a/validation/fd.tf
+++ b/validation/fd.tf
@@ -12,7 +12,6 @@ module "landing_zone" {
   project                    = var.project
   location                   = var.location
   frontends                  = var.frontends
-  enable_ssl                 = var.enable_ssl
   ssl_mode                   = var.ssl_mode
   resource_group             = var.resource_group
   subscription_id            = var.subscription_id

--- a/validation/variables.tf
+++ b/validation/variables.tf
@@ -28,10 +28,7 @@ variable "subscription_id" {
   description = "Enter ID of control Subscription"
   type        = string
 }
-variable "enable_ssl" {
-  description = "Enable SSL"
-  type        = bool
-}
+
 variable "ssl_mode" {
   description = "Certificate source to encrypted HTTPS traffic with"
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -57,6 +57,11 @@ variable "key_vault_resource_group" {
   type        = string
 }
 
+variable "add_access_policy" {
+  default = true
+  type = bool
+  description = "Whether to add an access policy for frontdoor to the subscription key vault, disable if there's multiple front doors in one subscription"
+}
 
 variable "log_analytics_workspace_id" {
   description = "Enter log analytics workspace id"

--- a/variables.tf
+++ b/variables.tf
@@ -54,8 +54,8 @@ variable "key_vault_resource_group" {
 }
 
 variable "add_access_policy" {
-  default = true
-  type = bool
+  default     = true
+  type        = bool
   description = "Whether to add an access policy for frontdoor to the subscription key vault, disable if there's multiple front doors in one subscription"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -28,10 +28,6 @@ variable "subscription_id" {
   description = "Enter Subscription ID"
   type        = string
 }
-variable "enable_ssl" {
-  description = "Enable SSL"
-  type        = bool
-}
 variable "ssl_mode" {
   description = "Certificate source to encrypt HTTPS traffic with. eg. AzureKeyVault, FrontDoor"
   type        = string


### PR DESCRIPTION
useful if you're deploying more than 1 frontdoor in a subscription