### PR TITLE
PUB-2124 - Added in optional firewall redirect / custom block

### DIFF
--- a/frontdoor_waf_policy.tf
+++ b/frontdoor_waf_policy.tf
@@ -9,8 +9,6 @@ resource "azurerm_frontdoor_firewall_policy" "custom" {
   enabled                           = true
   mode                              = lookup(each.value, "mode", "Prevention")
   redirect_url                      = lookup(each.value, "redirect_url", null)
-  custom_block_response_status_code = lookup(each.value, "custom_block_response_status_code", null)
-  custom_block_response_body        = lookup(each.value, "custom_block_response_body", null)
 
   managed_rule {
     type    = "DefaultRuleSet"

--- a/frontdoor_waf_policy.tf
+++ b/frontdoor_waf_policy.tf
@@ -3,11 +3,14 @@ resource "azurerm_frontdoor_firewall_policy" "custom" {
     frontend.name => frontend
     if lookup(frontend, "redirect", null) == null
   }
-  name                = "${replace(lookup(each.value, "name"), "-", "")}${replace(var.env, "-", "")}"
-  resource_group_name = var.resource_group
-  tags                = var.common_tags
-  enabled             = true
-  mode                = lookup(each.value, "mode", "Prevention")
+  name                              = "${replace(lookup(each.value, "name"), "-", "")}${replace(var.env, "-", "")}"
+  resource_group_name               = var.resource_group
+  tags                              = var.common_tags
+  enabled                           = true
+  mode                              = lookup(each.value, "mode", "Prevention")
+  redirect_url                      = lookup(each.value, "redirect_url", null)
+  custom_block_response_status_code = lookup(each.value, "custom_block_response_status_code", null)
+  custom_block_response_body        = lookup(each.value, "custom_block_response_body", null)
 
   managed_rule {
     type    = "DefaultRuleSet"

--- a/frontdoor_waf_policy.tf
+++ b/frontdoor_waf_policy.tf
@@ -3,12 +3,12 @@ resource "azurerm_frontdoor_firewall_policy" "custom" {
     frontend.name => frontend
     if lookup(frontend, "redirect", null) == null
   }
-  name                              = "${replace(lookup(each.value, "name"), "-", "")}${replace(var.env, "-", "")}"
-  resource_group_name               = var.resource_group
-  tags                              = var.common_tags
-  enabled                           = true
-  mode                              = lookup(each.value, "mode", "Prevention")
-  redirect_url                      = lookup(each.value, "redirect_url", null)
+  name                = "${replace(lookup(each.value, "name"), "-", "")}${replace(var.env, "-", "")}"
+  resource_group_name = var.resource_group
+  tags                = var.common_tags
+  enabled             = true
+  mode                = lookup(each.value, "mode", "Prevention")
+  redirect_url        = lookup(each.value, "redirect_url", null)
 
   managed_rule {
     type    = "DefaultRuleSet"


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/PUB-2124

### Change description ###

DRAFT PR

Added new option for frontdoor to help make the display more friendly when a request is blocked on a firewall rule

- Redirect URL: The URL that is used when a firewall rule is hit and the action is REDIRECT

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
