### PR TITLE
DTSPO-15720 - dns zone patch

### DIFF
--- a/frontdoor.tf
+++ b/frontdoor.tf
@@ -386,7 +386,7 @@ data "azurerm_dns_zone" "public_dns" {
     if azurerm_cdn_frontdoor_custom_domain.custom_domain[frontend.name].validation_token != ""
   }
   provider            = azurerm.public_dns
-  name                = lookup(each.value, "ssl_mode", "") == "AzureKeyVault" ? each.value.custom_domain : replace(each.value.custom_domain, "/^[^.]+\\./", "")
+  name                = lookup(each.value, "dns_zone_name", "") == "" ? lookup(each.value, "ssl_mode", "") == "AzureKeyVault" ? each.value.custom_domain : replace(each.value.custom_domain, "/^[^.]+\\./", "") : each.value.dns_zone_name
   resource_group_name = "reformmgmtrg"
 }
 

--- a/frontdoor.tf
+++ b/frontdoor.tf
@@ -386,7 +386,7 @@ data "azurerm_dns_zone" "public_dns" {
     if azurerm_cdn_frontdoor_custom_domain.custom_domain[frontend.name].validation_token != ""
   }
   provider            = azurerm.public_dns
-  name                = lookup(each.value, "dns_zone_name", "") == "" ? lookup(each.value, "ssl_mode", "") == "AzureKeyVault" ? each.value.custom_domain : replace(each.value.custom_domain, "/^[^.]+\\./", "") : each.value.dns_zone_name
+  name                = each.value.dns_zone_name
   resource_group_name = "reformmgmtrg"
 }
 


### PR DESCRIPTION
Fix: DNS zone not found when the custom domain is made of sub-domains e.g. `sign-in.pip-frontend.demo.platform.hmcts.net`