### PR TITLE
Create a new rule set "hsts_rules" for frontends have set hsts_header…

### DIFF
--- a/frontdoor.tf
+++ b/frontdoor.tf
@@ -145,7 +145,7 @@ resource "azurerm_cdn_frontdoor_route" "routing_rule_A" {
   # associate rule sets with this route checking two variables 'cache_enabled' and 'hsts_header_enabled'
   cdn_frontdoor_rule_set_ids = concat(
     lookup(each.value, "cache_enabled", "true") == "true" ? [azurerm_cdn_frontdoor_rule_set.caching_ruleset[each.key].id] : [],
-    lookup(each.value, "hsts_header_enabled", "true") == "true" ? [azurerm_cdn_frontdoor_rule_set.hsts_rules[each.key].id] : []
+    lookup(each.value, "hsts_header_enabled", "false") == "true" ? [azurerm_cdn_frontdoor_rule_set.hsts_rules[each.key].id] : []
   )
 
   enabled                = true

--- a/rules.tf
+++ b/rules.tf
@@ -96,7 +96,7 @@ resource "azurerm_cdn_frontdoor_rule_set" "hsts_rules" {
     for frontend in var.frontends : frontend.name => frontend
     if lookup(frontend, "hsts_header_enabled", "true") == "true"
   }
-  name                     = relace("${each.value.name}HstsRule", "-", "")
+  name                     = replace("${each.value.name}HstsRule", "-", "")
   cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.front_door.id
 }
 

--- a/rules.tf
+++ b/rules.tf
@@ -94,7 +94,7 @@ resource "azurerm_cdn_frontdoor_rule" "caching_rule" {
 resource "azurerm_cdn_frontdoor_rule_set" "hsts_rules" {
   for_each = {
     for frontend in var.frontends : frontend.name => frontend
-    if lookup(frontend, "hsts_header_enabled", "true") == "true"
+    if lookup(frontend, "hsts_header_enabled", "false") == "true"
   }
   name                     = replace("${each.value.name}HstsRule", "-", "")
   cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.front_door.id
@@ -103,7 +103,7 @@ resource "azurerm_cdn_frontdoor_rule_set" "hsts_rules" {
 resource "azurerm_cdn_frontdoor_rule" "hsts_header" {
   for_each = {
     for frontend in var.frontends : frontend.name => frontend
-    if lookup(frontend, "hsts_header_enabled", "true") == "true"
+    if lookup(frontend, "hsts_header_enabled", "false") == "true"
   }
 
   name                      = replace("${each.value.name}HstsHeader", "-", "")

--- a/rules.tf
+++ b/rules.tf
@@ -111,22 +111,10 @@ resource "azurerm_cdn_frontdoor_rule" "hsts_header" {
   order                     = 1
 
   actions {
-    dynamic "header_action" {
-      for_each = lookup(var.frontends[0], "hsts_header", {
-        header_action = [
-          {
-            header_action = "Overwrite"
-            header_name   = "Strict-Transport-Security"
-            value         = "max-age=31536000; includeSubDomains"
-          }
-        ]
-      }).header_action
-      iterator = action
-      content {
-        header_action = lookup(action.value, "header_action", null) != null ? action.value.header_action : "Overwrite"
-        header_name   = lookup(action.value, "header_name", null) != null ? action.value.header_name : "Strict-Transport-Security"
-        value         = lookup(action.value, "value", null) != null ? action.value.value : "max-age=31536000; includeSubDomains"
-      }
+    header_action {
+      header_action = "Overwrite"
+      header_name   = "Strict-Transport-Security"
+      value         = "max-age=31536000; includeSubDomains"
     }
   }
 }

--- a/rules.tf
+++ b/rules.tf
@@ -90,3 +90,43 @@ resource "azurerm_cdn_frontdoor_rule" "caching_rule" {
 
   depends_on = [azurerm_cdn_frontdoor_origin_group.defaultBackend, azurerm_cdn_frontdoor_origin.defaultBackend_origin]
 }
+
+resource "azurerm_cdn_frontdoor_rule_set" "hsts_rules" {
+  for_each = {
+    for frontend in var.frontends : frontend.name => frontend
+    if lookup(frontend, "hsts_header_enabled", "true") == "true"
+  }
+  name                     = relace("${each.value.name}HstsRule", "-", "")
+  cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.front_door.id
+}
+
+resource "azurerm_cdn_frontdoor_rule" "hsts_header" {
+  for_each = {
+    for frontend in var.frontends : frontend.name => frontend
+    if lookup(frontend, "hsts_header_enabled", "true") == "true"
+  }
+
+  name                      = replace("${each.value.name}HstsHeader", "-", "")
+  cdn_frontdoor_rule_set_id = azurerm_cdn_frontdoor_rule_set.hsts_rules.id
+  order                     = 1
+
+  actions {
+    dynamic "header_action" {
+      for_each = lookup(var.frontends[0], "hsts_header", {
+        header_action = [
+          {
+            header_action = "Overwrite"
+            header_name   = "Strict-Transport-Security"
+            value         = "max-age=31536000; includeSubDomains"
+          }
+        ]
+      }).header_action
+      iterator = action
+      content {
+        header_action = lookup(action.value, "header_action", null) != null ? action.value.header_action : "Overwrite"
+        header_name   = lookup(action.value, "header_name", null) != null ? action.value.header_name : "Strict-Transport-Security"
+        value         = lookup(action.value, "value", null) != null ? action.value.value : "max-age=31536000; includeSubDomains"
+      }
+    }
+  }
+}

--- a/rules.tf
+++ b/rules.tf
@@ -111,7 +111,7 @@ resource "azurerm_cdn_frontdoor_rule" "hsts_header" {
   order                     = 1
 
   actions {
-    header_action {
+    response_header_action {
       header_action = "Overwrite"
       header_name   = "Strict-Transport-Security"
       value         = "max-age=31536000; includeSubDomains"

--- a/rules.tf
+++ b/rules.tf
@@ -107,7 +107,7 @@ resource "azurerm_cdn_frontdoor_rule" "hsts_header" {
   }
 
   name                      = replace("${each.value.name}HstsHeader", "-", "")
-  cdn_frontdoor_rule_set_id = azurerm_cdn_frontdoor_rule_set.hsts_rules.id
+  cdn_frontdoor_rule_set_id = azurerm_cdn_frontdoor_rule_set.hsts_rules[each.key].id
   order                     = 1
 
   actions {


### PR DESCRIPTION
### Jira link

See DTSPO-23861(https://tools.hmcts.net/jira/browse/dtspo-23861)

### Change description
This PR aims to create necessary Frontdoor resources for setting HTTP header `Strict-Transport-Security`

### Testing done

[sds-azure-platform](https://dev.azure.com/hmcts/PlatformOperations/_build/results?buildId=809609&view=results) ci pipeline
TF plan
```
 
      - record {
          - value = "_hru2od60mfhcb9ru4vxi5mn6raq6atd" -> null
        }
      + record {
          + value = "validated"
        }
    }

  # module.premium_front_door.azurerm_monitor_diagnostic_setting.diagnostics_access_logs_sa[0] will be updated in-place
  ~ resource "azurerm_monitor_diagnostic_setting" "diagnostics_access_logs_sa" {
        id                             = "/subscriptions/a8140a9e-f1b0-481f-a4de-09e2ee23f7ab/resourceGroups/lz-sbox-rg/providers/Microsoft.Cdn/profiles/sdshmcts-sbox|fd-log-analytics-logs-sa"
        name                           = "fd-log-analytics-logs-sa"
        # (6 unchanged attributes hidden)

      - metric {
          - category = "AllMetrics" -> null
          - enabled  = false -> null

          - retention_policy {
              - days    = 0 -> null
              - enabled = false -> null
            }
        }

        # (4 unchanged blocks hidden)
    }
Plan: 2 to add, 3 to change, 0 to destroy.
```
- also you can check the frontdoor `sdshmcts-sbox` 
  - a new rule set `toffeeHstsRule` created
  - an existing route `toffee` is updated with the new rule set `toffeeHstsRule`


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [x] Does this PR introduce a breaking change
